### PR TITLE
Add GetTimestamp() To Result

### DIFF
--- a/hsperfdata/file.go
+++ b/hsperfdata/file.go
@@ -72,7 +72,10 @@ func (datafile *File) Read() (*Result, error) {
 		}
 	}
 
-	result := &Result{make(map[string]interface{})}
+	result := &Result{
+		data:         make(map[string]interface{}),
+		modTimestamp: prologue.ModTimestamp,
+	}
 
 	start_offset := prologue.EntryOffset
 
@@ -105,7 +108,7 @@ func (datafile *File) Read() (*Result, error) {
 				return nil, fmt.Errorf("Cannot read binary: %v", err)
 			}
 
-			result.data[name] = fmt.Sprintf("%v", i)
+			result.data[name] = i
 		} else {
 			if entry.DataType != TYPE_BYTE || entry.DataUnits != UNITS_STRING || (entry.DataVar != VARIABILITY_CONSTANT && entry.DataVar != VARIABILITY_VARIABLE) {
 				return nil, fmt.Errorf("Unexpected vector monitor: DataType:%c,DataUnits:%v,DataVar:%v", entry.DataType, entry.DataUnits, entry.DataVar)

--- a/hsperfdata/hsperfdata_test.go
+++ b/hsperfdata/hsperfdata_test.go
@@ -2,6 +2,7 @@ package hsperfdata
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNew(t *testing.T) {
@@ -27,7 +28,16 @@ func TestNew(t *testing.T) {
 	path := result.GetString("sun.property.sun.boot.library.path")
 	expected := "/Library/Java/JavaVirtualMachines/jdk1.8.0_31.jdk/Contents/Home/jre/lib"
 	if path != expected {
-		t.Errorf("sun.property.sun.boot.library.path miss match: '%#v'(len:%d) != '%#v'(len:%d)", path, len(path), expected, len(expected))
+		t.Errorf("sun.property.sun.boot.library.path mismatch: '%#v'(len:%d) != '%#v'(len:%d)", path, len(path), expected, len(expected))
+	}
+
+	expectedTime := time.Date(2015, time.June, 12, 4, 54, 14, 428000000, time.UTC)
+	actualTime, err := result.GetTimestamp()
+	if err != nil {
+		t.Error(err)
+	}
+	if actualTime.In(time.UTC) != expectedTime {
+		t.Errorf("ModTimestamp mismatch: '%v' != '%v'", actualTime.In(time.UTC), expectedTime)
 	}
 
 	{

--- a/hsperfdata/result.go
+++ b/hsperfdata/result.go
@@ -1,18 +1,34 @@
 package hsperfdata
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 type Result struct {
-	data map[string]interface{}
+	data         map[string]interface{}
+	modTimestamp int64
 }
 
 func (self *Result) GetMap() map[string]interface{} {
 	return self.data
 }
 
+func (self *Result) GetTimestamp() (time.Time, error) {
+	if createVmBeginTime, ok := self.data["sun.rt.createVmBeginTime"]; ok {
+		if now, ok := createVmBeginTime.(int64); ok {
+			return time.Unix(0, (now+self.modTimestamp)*int64(time.Millisecond)), nil
+		} else {
+			return time.Time{}, fmt.Errorf("sun.rt.createVmBeginTime wasn't an int64: %#v", createVmBeginTime)
+		}
+	} else {
+		return time.Time{}, fmt.Errorf("couldn't find sun.rt.createVmBeginTime to add prologue ModTimestamp %v to", self.modTimestamp)
+	}
+}
+
 func (self *Result) GetProcName() string {
-	javaCommand := self.data["sun.rt.javaCommand"]
-	if javaCommand != nil {
+	if javaCommand, ok := self.data["sun.rt.javaCommand"]; ok {
 		if str, ok := javaCommand.(string); ok {
 			splitted := strings.SplitN(str, " ", 2)
 			return splitted[0]


### PR DESCRIPTION
...so you can see when the readings were as of. This change also removes
the convert-all-values-to-strings functionality, so Java Long-type perf
counters are returned as Go int64 Result.GetData().