### PR TITLE
hsstat.go needs pid := os.Args[1] changed to flag.Args()[0]

### DIFF
--- a/hsstat/hsstat.go
+++ b/hsstat/hsstat.go
@@ -31,7 +31,7 @@ func main() {
 		return
 	}
 
-	pid := os.Args[1]
+	pid := flag.Args()[0]
 
 	repo, err := newRepository(*user)
 	if err != nil {


### PR DESCRIPTION
Line 34 in hsstat.go needs a change:

When used with -u <user>, -u will be os.Args[1], leading to the following error:

> $ hsstat  -u nobody 123
> 2018/10/07 21:47:49 open failopen /tmp/hsperfdata_nobody/-u: no such file or directory

Instead use:

> pid := flag.Args()[0]